### PR TITLE
Add quant entries

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -30,6 +30,11 @@ params = json.load(open("generation_params.json", "r"))
 
 data = {}
 
+# Load quantization types
+with open("quants.csv", newline="") as quantfile:
+    quant_reader = csv.DictReader(quantfile)
+    quants = [row["quant"].strip() for row in quant_reader if row["quant"].strip()]
+
 with open(input_file, newline="") as csvfile:
     reader = csv.DictReader(csvfile)
     for row in reader:
@@ -75,7 +80,12 @@ with open(input_file, newline="") as csvfile:
         row = {k: v for k, v in row.items() if v}
 
         # Add the model record to the data
-        for key_format in ["{name}", "aphrodite/{name}", "koboldcpp/{model_name}"]:
+        key_formats = ["{name}", "aphrodite/{name}", "koboldcpp/{model_name}"]
+        for quant in quants:
+            key_formats.append(f"aphrodite/{{name}}.{quant}")
+            key_formats.append(f"koboldcpp/{{model_name}}.{quant}")
+
+        for key_format in key_formats:
             key = key_format.format(name=name, model_name=model_name)
             data[key] = {"name": key, "model_name": model_name, **defaults, **row}
 


### PR DESCRIPTION
## Summary
- revert the binary `db.json` to avoid large diff
- load available quants from `quants.csv`
- create model entries for each quantization for both aphrodite and koboldcpp

## Testing
- `pre-commit run --files convert.py quants.csv models.csv defaults.json generation_params.json db.json` *(fails: pre-commit not found)*
- `python convert.py`

------
https://chatgpt.com/codex/tasks/task_e_6863558652708333bd68798d8bd9eb67